### PR TITLE
Potential fix for code scanning alert no. 5: Useless regular-expression character escape

### DIFF
--- a/docs/yuidoc-p5-theme/assets/js/reference.js
+++ b/docs/yuidoc-p5-theme/assets/js/reference.js
@@ -3395,7 +3395,7 @@ var prettyPrint;
       // only when not following [|&;<>].
       '^.[^\\s\\w.$@\'"`/\\\\]*';
     if (options['regexLiterals']) {
-      punctuation += '(?!\s*\/)';
+      punctuation += '(?!\\s*\\/)';
     }
 
     fallthroughStylePatterns.push(


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/p5.js/security/code-scanning/5](https://github.com/se2026/p5.js/security/code-scanning/5)

To fix the problem, we need to double all backslashes in the string literal that are intended to be regular expression escapes, so that they survive through the JavaScript string literal parsing and are seen as escapes by the regular expression engine. Specifically, replace `\s` with `\\s`, and `\/` with `\\/` (though `\/` is interpreted as just `/`, which does not require escaping in a string, but for consistency and clarity, it's often better to escape the `/` inside a regex). Update the affected line in `docs/yuidoc-p5-theme/assets/js/reference.js` at line 3398.

No new imports, definitions, or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
