### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/typography/p5.Font.js
+++ b/src/typography/p5.Font.js
@@ -362,7 +362,7 @@ p5.Font = class {
       x = xOriginal;
       let line = lines[i];
 
-      line = line.replace('\t', '  ');
+      line = line.replace(/\t/g, '  ');
       const glyphs = this._getGlyphs(line);
 
       for (let j = 0; j < glyphs.length; j++) {


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/p5.js/security/code-scanning/2](https://github.com/se2026/p5.js/security/code-scanning/2)

To fix the problem, update the `replace` method so that it replaces all occurrences of the tab character in the string with two spaces, not just the first. In JavaScript, this is achieved by passing a regular expression `/\t/g` as the first argument to `replace`, where the `g` flag stands for "global" (i.e., replace all). 

Edit only the affected line in `src/typography/p5.Font.js` (line 365), changing:
```js
line = line.replace('\t', '  ');
```
to
```js
line = line.replace(/\t/g, '  ');
```
No other edits, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
